### PR TITLE
[Fix] 카테고리 및 달력 UI 버그 수정

### DIFF
--- a/Clokey/Clokey.xcodeproj/project.pbxproj
+++ b/Clokey/Clokey.xcodeproj/project.pbxproj
@@ -2214,11 +2214,9 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = Clokey/Clokey.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = BBVZV8T99P;
+				DEVELOPMENT_TEAM = BBVZV8T99P;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Clokey/Supporting Files/Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -2238,7 +2236,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.clokeyteam.clokey;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Clokey;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -2258,11 +2255,9 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = Clokey/Clokey.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = BBVZV8T99P;
+				DEVELOPMENT_TEAM = BBVZV8T99P;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Clokey/Supporting Files/Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -2282,7 +2277,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.clokeyteam.clokey;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Clokey;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Clokey/Clokey/Sources/Common/Components/Category/AddCategoryView.swift
+++ b/Clokey/Clokey/Sources/Common/Components/Category/AddCategoryView.swift
@@ -10,6 +10,11 @@ class AddCategoryView: UIView {
         return [springImageView, summerImageView, autumnImageView, winterImageView]
     }
     
+    // 라벨 선택
+    private var seasonLabelViews: [UILabel] {
+        return [springLabel, summerLabel, autumnLabel, winterLabel]
+    }
+    
     let backButton = UIButton().then {
         $0.setImage(UIImage(systemName: "chevron.backward"), for: .normal)
         $0.tintColor = UIColor(named: "mainBrown800")
@@ -44,7 +49,7 @@ class AddCategoryView: UIView {
         let label = UILabel()
         label.text = "봄"
         label.font = UIFont.ptdRegularFont(ofSize: 16)
-        label.textColor = .black
+        label.textColor = .mainBrown800
         label.textAlignment = .center
         return label
     }()
@@ -62,7 +67,7 @@ class AddCategoryView: UIView {
         let label = UILabel()
         label.text = "여름"
         label.font = UIFont.ptdRegularFont(ofSize: 16)
-        label.textColor = .black
+        label.textColor = .mainBrown800
         label.textAlignment = .center
         return label
     }()
@@ -80,7 +85,7 @@ class AddCategoryView: UIView {
         let label = UILabel()
         label.text = "가을"
         label.font = UIFont.ptdRegularFont(ofSize: 16)
-        label.textColor = .black
+        label.textColor = .mainBrown800
         label.textAlignment = .center
         return label
     }()
@@ -98,7 +103,7 @@ class AddCategoryView: UIView {
         let label = UILabel()
         label.text = "겨울"
         label.font = UIFont.ptdRegularFont(ofSize: 16)
-        label.textColor = .black
+        label.textColor = .mainBrown800
         label.textAlignment = .center
         return label
     }()
@@ -248,15 +253,27 @@ class AddCategoryView: UIView {
     
     // 계절 선택
     func updateSelectedSeason(_ imageView: UIImageView) {
-       // 모든 이미지뷰의 테두리 초기화
-       seasonImageViews.forEach { view in
-           view.layer.borderWidth = 0
-       }
+        // 모든 이미지뷰의 테두리 초기화
+        seasonImageViews.forEach { view in
+            view.layer.borderWidth = 0
+        }
        
-       // 선택된 이미지뷰에 테두리 추가
-       imageView.layer.borderWidth = 3
-       imageView.layer.borderColor = UIColor(named: "mainBrown800")?.cgColor
-   }
+        // 선택된 이미지뷰에 테두리 추가
+        imageView.layer.borderWidth = 3
+        imageView.layer.borderColor = UIColor(named: "mainBrown800")?.cgColor
+        
+        // 글씨 굵게
+        for (index, view) in seasonLabelViews.enumerated() {
+            view.layer.borderWidth = 0
+            seasonLabelViews[index].font = .ptdMediumFont(ofSize: 16)
+        }
+        
+        // 선택된 이미지 뷰에 테두리 & 라벨 두께
+        if let selectedIndex = seasonImageViews.firstIndex(of: imageView) {
+            imageView.layer.borderWidth = 3
+            imageView.layer.borderColor = UIColor(named: "mainBrown800")?.cgColor
+            seasonLabelViews[selectedIndex].font = UIFont.ptdBoldFont(ofSize: 16)
+        }   }
 
 }
 

--- a/Clokey/Clokey/Sources/Feature/Calendar/CustomCalendar/Calendar/CalendarCell.swift
+++ b/Clokey/Clokey/Sources/Feature/Calendar/CustomCalendar/Calendar/CalendarCell.swift
@@ -85,36 +85,25 @@ class CalendarCell: UICollectionViewCell {
         imageView.isHidden = !isCurrentMonth
         imageView.kf.cancelDownloadTask()
 
-        if isToday {
+        todayView.isHidden = true
+        
+        if isCurrentMonth, isToday {
             todayView.isHidden = false
             dayLabel.textColor = .white
         } else {
-            todayView.isHidden = true
-            
-            if isSelected {
-                contentView.backgroundColor = .systemBlue.withAlphaComponent(0.3)
-                dayLabel.textColor = .black
-            } else {
-                contentView.backgroundColor = .white
-                dayLabel.textColor = .black
-            }
+            dayLabel.textColor = .black
         }
-        
-//        // 로딩 전 셀 리셋
-//        imageView.image = nil
-//        
-//        // 이미지 로딩
-//        if let imageUrl = imageUrl, let url = URL(string: imageUrl) {
-//            todayView.isHidden = true
-//            imageView.kf.setImage(with: url, placeholder: UIImage(named: "placeholder"))
-//        } else {
-//            imageView.image = nil
-//        }
         // 현재 달의 셀에만 이미지 표시
         if isCurrentMonth, let imageUrl = imageUrl, let url = URL(string: imageUrl) {
             imageView.isHidden = false
             todayView.isHidden = true
             imageView.kf.setImage(with: url, placeholder: UIImage(named: "placeholder"))
+        }
+        // 선택된 날짜
+        if isSelected {
+            contentView.backgroundColor = .systemBlue.withAlphaComponent(0.3)
+        } else {
+            contentView.backgroundColor = .white
         }
     }
     

--- a/Clokey/Clokey/Sources/Feature/Calendar/CustomCalendar/Calendar/CalendarView.swift
+++ b/Clokey/Clokey/Sources/Feature/Calendar/CustomCalendar/Calendar/CalendarView.swift
@@ -146,19 +146,6 @@ extension CalendarView: UICollectionViewDataSource, UICollectionViewDelegate {
         dateFormatter.dateFormat = "yyyy-MM-dd"
         let dateString = dateFormatter.string(from: date)
 
-//        let imageMapping: [String: UIImage] = [
-//            "2025-02-05": UIImage(named: "sample_image")!, // 2월 5일
-//            "2025-02-12": UIImage(named: "sample_image")!, // 2월 12일
-//            "2025-02-04": UIImage(named: "sample_image")!,
-//            "2025-02-09": UIImage(named: "sample_image")!,
-//            "2025-02-23": UIImage(named: "sample_image")!,
-//            "2025-02-22": UIImage(named: "sample_image")!,
-//            "2025-02-28": UIImage(named: "sample_image")!
-//            
-//        ]
-//        
-//        let image = imageMapping[dateString]
-        
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
 //        let dateString = formatter.string(from: date)

--- a/Clokey/Clokey/Sources/Feature/Home/ViewControllers/HomeViewController.swift
+++ b/Clokey/Clokey/Sources/Feature/Home/ViewControllers/HomeViewController.swift
@@ -43,7 +43,7 @@ final class HomeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: animated)
-        selectTab(.pick)
+        
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type] 작업내용 -->
<!-- 예시: [Feature] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
 카테고리 및 달력 UI 버그 수정

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 카테고리 계절 선택 시, 각 계절 글자 ptdBold로 설정 완료
- 커스텀 캘린더에서 다음 달로 넘겼을 때, 오늘 날짜가 빈 날짜에 표시 되는 버그 수정


## 🔍 테스트 체크리스트
<!-- 테스트한 항목을 체크해주세요 -->
- [x] 시뮬레이터 테스트 완료
- [x] 기획서의 기능 요구사항 만족
- [x] 코드 컨벤션 준수
- [x] 화면 UI가 디자인과 일치
- [x] 네트워크 연결/비연결 상태 확인 (API 호출이 있는 경우)

### ❗️주의사항
<!-- 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
