### PR TITLE
[Fix] 프로필 달력에서 기록 체크 시, 본인 확인 기능 

### DIFF
--- a/Clokey/Clokey.xcodeproj/project.pbxproj
+++ b/Clokey/Clokey.xcodeproj/project.pbxproj
@@ -2320,11 +2320,9 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = Clokey/Clokey.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = BBVZV8T99P;
+				DEVELOPMENT_TEAM = BBVZV8T99P;
 				ENABLE_DEBUG_DYLIB = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Clokey/Supporting Files/Info.plist";
@@ -2346,7 +2344,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.clokeyteam.clokey;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Clokey;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -2366,12 +2363,10 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = Clokey/Clokey.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = BBVZV8T99P;
+				DEVELOPMENT_TEAM = BBVZV8T99P;
 				ENABLE_DEBUG_DYLIB = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Clokey/Supporting Files/Info.plist";
@@ -2393,7 +2388,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.clokeyteam.clokey;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Clokey;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Clokey/Clokey/Sources/Feature/Calendar/AddOOTD/RecordOOTDView.swift
+++ b/Clokey/Clokey/Sources/Feature/Calendar/AddOOTD/RecordOOTDView.swift
@@ -38,7 +38,16 @@ class RecordOOTDView: UIView {
         $0.color = UIColor(named: "pointOrange800")
         $0.hidesWhenStopped = true
         $0.backgroundColor = .clear
+        $0.isUserInteractionEnabled = true
     }
+    
+    // 터치 차단을 뷰
+    let touchBlockingView = UIView().then {
+        $0.backgroundColor = UIColor.black.withAlphaComponent(0.1) // 반투명 배경
+        $0.isUserInteractionEnabled = true
+        $0.isHidden = true // 기본적으로 숨김
+    }
+
     
     // MARK: - Init
     
@@ -61,7 +70,8 @@ class RecordOOTDView: UIView {
         addSubview(scrollView)
         addSubview(OOTDButton)  // 스크롤뷰와 별개로 추가
         addSubview(loadingIndicator)
-        
+        addSubview(touchBlockingView)
+
         scrollView.addSubview(contentView)
         
         contentView.addSubview(photoTagView)
@@ -107,6 +117,9 @@ class RecordOOTDView: UIView {
         loadingIndicator.snp.makeConstraints {
             $0.center.equalToSuperview()
         }
+        touchBlockingView.snp.makeConstraints {
+            $0.edges.equalToSuperview() // 전체 화면을 덮음
+        }
     }
     
     
@@ -116,4 +129,15 @@ class RecordOOTDView: UIView {
     func updateCollectionViewHeight(_ hasImages: Bool) {
         photoTagView.updateCollectionViewHeight(hasImages)
     }
+    
+    func showTouchBlockingView() {
+        touchBlockingView.isHidden = false
+        bringSubviewToFront(touchBlockingView) // 최상단으로 올림
+        bringSubviewToFront(loadingIndicator) // 로딩 인디케이터도 같이 보이도록 설정
+    }
+
+    func hideTouchBlockingView() {
+        touchBlockingView.isHidden = true
+    }
+
 }

--- a/Clokey/Clokey/Sources/Feature/Calendar/AddOOTD/RecordOOTDViewController.swift
+++ b/Clokey/Clokey/Sources/Feature/Calendar/AddOOTD/RecordOOTDViewController.swift
@@ -207,6 +207,7 @@ class RecordOOTDViewController: UIViewController, UIGestureRecognizerDelegate {
             }
             
             DispatchQueue.main.async {
+                self.mainView.showTouchBlockingView()
                 self.mainView.loadingIndicator.startAnimating()
             }
             
@@ -215,6 +216,7 @@ class RecordOOTDViewController: UIViewController, UIGestureRecognizerDelegate {
                 guard let self = self else { return }
                 
                 DispatchQueue.main.async {
+                    self.mainView.hideTouchBlockingView()
                     self.mainView.loadingIndicator.stopAnimating()
                 }
                 

--- a/Clokey/Clokey/Sources/Feature/Profile/My/ProfileViewController.swift
+++ b/Clokey/Clokey/Sources/Feature/Profile/My/ProfileViewController.swift
@@ -97,7 +97,6 @@ final class ProfileViewController: UIViewController {
         calendarViewController.removeFromParent()
     }
     
-    
     var nickname: String = ""
     var profileImage: String = ""
     var backgroundImage: String = ""

--- a/Clokey/Clokey/Sources/Feature/Profile/Settings/SettingViewController.swift
+++ b/Clokey/Clokey/Sources/Feature/Profile/Settings/SettingViewController.swift
@@ -98,7 +98,7 @@ class SettingViewController: UIViewController, UIGestureRecognizerDelegate {
         setupButtonActions(for: settingView.LikedHistoryContainer, action: #selector(didTapLikedHistory))
         // 내가 쓴 댓글
         setupButtonActions(for: settingView.HistoryCommentContainer, action: #selector(didTapHistoryComment))
-        setupButtonActions(for: settingView.blokedAccountButton, action: #selector(didTapBlockButton))
+        setupButtonActions(for: settingView.blokedAccountContainer, action: #selector(didTapBlockButton))
 
     }
     

--- a/Clokey/Clokey/Sources/Feature/Profile/Your/FollowCalendarViewController.swift
+++ b/Clokey/Clokey/Sources/Feature/Profile/Your/FollowCalendarViewController.swift
@@ -24,6 +24,7 @@ class FollowCalendarViewController: UIViewController {
     private var historyIdMap: [String: Int] = [:]
     
     var followId: String = ""
+    var isMe: Bool = false // 본인 확인 
     
     // MARK: - UI Components
     
@@ -172,7 +173,7 @@ class FollowCalendarViewController: UIViewController {
 
     
     // MARK: - Calendar Methods
-    private func updateCalendar() {
+    func updateCalendar() {
         
         // CalendarHelper 로 날짜들 생성
         dates = CalendarHelper.generateDates(for: currentMonth)
@@ -248,15 +249,23 @@ extension FollowCalendarViewController: CalendarViewDelegate {
             switch result {
             case .success(let response):
                 print("히스토리 상세 조회 성공: \(response)")
-                let detailVC = FriendsCalendarDetailViewController()
-                detailVC.setDetailData(response) //  상세 데이터 전달
-                self.navigationController?.pushViewController(detailVC, animated: true)
+                
+                if isMe {
+                    // 본인 -> CalendarDetailViewController로
+                    let detailVC = CalendarDetailViewController()
+                    detailVC.setDetailData(response)
+                    self.navigationController?.pushViewController(detailVC, animated: true)
+                } else {
+                    // 타인 -> FriendsCalendarDetailViewController로
+                    let detailVC = FriendsCalendarDetailViewController()
+                    detailVC.setDetailData(response)
+                    self.navigationController?.pushViewController(detailVC, animated: true)
+                }
 
             case .failure(let error):
                 print("히스토리 상세 조회 실패: \(error.localizedDescription)")
             }
         }
     }
-
 }
 

--- a/Clokey/Clokey/Sources/Feature/Profile/Your/FollowProfileViewController.swift
+++ b/Clokey/Clokey/Sources/Feature/Profile/Your/FollowProfileViewController.swift
@@ -163,7 +163,6 @@ class FollowProfileViewController: UIViewController, UIGestureRecognizerDelegate
             switch result {
             case .success(let userProfile):
                 DispatchQueue.main.async {
-
                     self.clokey_Id = userProfile.clokeyId
                     self.followProfileView.nicknameLabel.text = userProfile.nickname
                     self.followProfileView.writeCountLabel.text = "\(userProfile.recordCount)"
@@ -333,7 +332,7 @@ class FollowProfileViewController: UIViewController, UIGestureRecognizerDelegate
                         }
                     }
                 case .failure(let error):
-                    print("🚨 팔로우/언팔로우 요청 실패: \(error.localizedDescription)")
+                    print("팔로우/언팔로우 요청 실패: \(error.localizedDescription)")
                 }
             }
         }

--- a/Clokey/Clokey/Sources/Feature/Profile/Your/FollowProfileViewController.swift
+++ b/Clokey/Clokey/Sources/Feature/Profile/Your/FollowProfileViewController.swift
@@ -23,7 +23,8 @@ class FollowProfileViewController: UIViewController, UIGestureRecognizerDelegate
     private var loadingOverlay: UIView?
     
     private let followCalendarViewController = FollowCalendarViewController()
-    
+    private let calendarViewController = CalendarViewController()
+
     var followId: String = ""
     var isMe: Bool = false
     
@@ -155,7 +156,6 @@ class FollowProfileViewController: UIViewController, UIGestureRecognizerDelegate
         
         let membersService = MembersService()
         
-        
         // MARK: - 사용자 정보 받아서 로드하는 API
         membersService.getUserProfile(clokey_id: followId) { [weak self] result in
             guard let self = self else { return }
@@ -163,6 +163,7 @@ class FollowProfileViewController: UIViewController, UIGestureRecognizerDelegate
             switch result {
             case .success(let userProfile):
                 DispatchQueue.main.async {
+                    self.isMe = userProfile.isMe
                     self.clokey_Id = userProfile.clokeyId
                     self.followProfileView.nicknameLabel.text = userProfile.nickname
                     self.followProfileView.writeCountLabel.text = "\(userProfile.recordCount)"
@@ -184,6 +185,10 @@ class FollowProfileViewController: UIViewController, UIGestureRecognizerDelegate
                     }
                     
                     let clothes = userProfile.clothResults
+                    
+                    self.followCalendarViewController.followId = self.followId
+                    self.followCalendarViewController.isMe = self.isMe
+                    self.followCalendarViewController.updateCalendar()
                     
                     self.followProfileView.clothesImageView2.isHidden = clothes.isEmpty || clothes.count < 2
                     self.followProfileView.clothesImageView3.isHidden = clothes.isEmpty || clothes.count < 3

--- a/Clokey/Clokey/Sources/Network/members/Endpoints/MembersEndpoint.swift
+++ b/Clokey/Clokey/Sources/Network/members/Endpoints/MembersEndpoint.swift
@@ -23,6 +23,7 @@ public enum MembersEndpoint {
     case optionalTermAgree(data: OptionalTermAgreeRequestDTO)
     case getFollowPeople(clokeyId: String, page: Int, isFollowing: Bool)
     case blockMember(clokeyId: String)
+    case checkMySelf(clokeyId: String)
     // 추가적인 API는 여기 케이스로 정의
 }
 
@@ -63,6 +64,8 @@ extension MembersEndpoint: TargetType {
             return "/users/\(clokeyId)/follow"
         case .blockMember(let clokeyId):
             return "/users/block/\(clokeyId)"
+        case .checkMySelf:
+            return "users/check-myself"
         }
     }
     
@@ -73,7 +76,7 @@ extension MembersEndpoint: TargetType {
             return .post
         case .updateProfile:
             return .patch
-        case .checkIdAvailability, .getUserProfile, .getTerms, .getAgreedTerms, .getFollowPeople:
+        case .checkIdAvailability, .getUserProfile, .getTerms, .getAgreedTerms, .getFollowPeople, .checkMySelf:
             return .get
         case .unfollowUser:
             return .delete
@@ -121,7 +124,6 @@ extension MembersEndpoint: TargetType {
                     print("📂 Multipart 데이터 추가됨: \(item.name)")
                 }
             }
-            
             return .uploadMultipart(multipartData)
         case .checkIdAvailability(_):
             return .requestPlain
@@ -131,8 +133,7 @@ extension MembersEndpoint: TargetType {
                 parameters["clokey_id"] = clokey_id
             }
             return .requestParameters(parameters: parameters, encoding: URLEncoding.default)
-            //        case .getUser:
-            //            return .requestPlain
+
         case .followUser(_):
             return .requestPlain
         case .unfollowUser(let data):
@@ -149,6 +150,8 @@ extension MembersEndpoint: TargetType {
             return .requestParameters(parameters: parameters, encoding: URLEncoding.default)
         case .blockMember(_):
             return .requestPlain
+        case .checkMySelf(let clokeyId):
+            return .requestParameters(parameters: ["clokeyId": clokeyId], encoding: URLEncoding.queryString)
         }
     }
     

--- a/Clokey/Clokey/Sources/Network/members/Endpoints/MembersEndpoint.swift
+++ b/Clokey/Clokey/Sources/Network/members/Endpoints/MembersEndpoint.swift
@@ -79,8 +79,7 @@ extension MembersEndpoint: TargetType {
             return .post
         case .updateProfile:
             return .patch
-        case .checkIdAvailability, .getUserProfile, .getTerms, .getAgreedTerms, .getFollowPeople, .checkMySelf:
-        case .checkIdAvailability, .getUserProfile, .getTerms, .getAgreedTerms, .getFollowPeople, .getBlockMembers:
+        case .checkIdAvailability, .getUserProfile, .getTerms, .getAgreedTerms, .getFollowPeople, .checkMySelf, .getBlockMembers:
             return .get
         case .unfollowUser:
             return .delete

--- a/Clokey/Clokey/Sources/Network/members/Response/MembersInfoResponseDTO.swift
+++ b/Clokey/Clokey/Sources/Network/members/Response/MembersInfoResponseDTO.swift
@@ -61,6 +61,8 @@ public struct GetFollowPeopleResponseDTO: Codable {
 // 본인 확인
 public struct CheckMeResponseDTO: Codable {
     public let isMe: Bool
+}
+
 public struct GetBlockMembersResponseDTO: Codable {
     let members: [Members]
     let totalPage: Int

--- a/Clokey/Clokey/Sources/Network/members/Response/MembersInfoResponseDTO.swift
+++ b/Clokey/Clokey/Sources/Network/members/Response/MembersInfoResponseDTO.swift
@@ -58,4 +58,7 @@ public struct GetFollowPeopleResponseDTO: Codable {
     }
 }
 
-
+// 본인 확인
+public struct CheckMeResponseDTO: Codable {
+    public let isMe: Bool
+}

--- a/Clokey/Clokey/Sources/Network/members/Response/MembersInfoResponseDTO.swift
+++ b/Clokey/Clokey/Sources/Network/members/Response/MembersInfoResponseDTO.swift
@@ -22,6 +22,7 @@ public struct MembersInfoResponseDTO: Codable {
     public let visibility: String
     public let clothResults: [ClothResult]
     public let isFollowing: Bool?
+    public let isMe:Bool
     
     public struct ClothResult: Codable {
         public let clothId: Int64?

--- a/Clokey/Clokey/Sources/Network/members/Service/MembersService.swift
+++ b/Clokey/Clokey/Sources/Network/members/Service/MembersService.swift
@@ -196,4 +196,16 @@ public final class MembersService: NetworkManager {
             }
         )
     }
+    
+    // 본인확인 GET API
+    public func checkMySelf(
+        clokeyId: String,
+        completion: @escaping (Result<CheckMeResponseDTO, NetworkError>) -> Void
+    ) {
+        request(
+            target: .checkMySelf(clokeyId: clokeyId),
+            decodingType: CheckMeResponseDTO.self,
+            completion: completion
+        )
+    }
 }

--- a/Clokey/Clokey/Sources/Network/report/Response/ReportResponseDTO.swift
+++ b/Clokey/Clokey/Sources/Network/report/Response/ReportResponseDTO.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 // 신고 정보 조회 통합
-// 신고 정보 조회 통합
 public struct ReportResponseDTO<T: Codable>: Codable {
     public let clokeyId: String
     public let nickName: String


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type] 작업내용 -->
<!-- 예시: [Feature] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
설정 버튼 설정 오류 해결
프로필 달력에서 본인/타인 구분 완료

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 본인확인 API 수정
- 설정 버튼 버그 수정
- 프로필 달력에서 기록 선택 시, 본인/타인 구분하는 기능 추가


## 🔍 테스트 체크리스트
<!-- 테스트한 항목을 체크해주세요 -->
- [x] 시뮬레이터 테스트 완료
- [x] 기획서의 기능 요구사항 만족
- [x] 코드 컨벤션 준수
- [x] 화면 UI가 디자인과 일치
- [x] 네트워크 연결/비연결 상태 확인 (API 호출이 있는 경우)

### ❗️주의사항
<!-- 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
타고타고 들어간 본인 프로필에서 기록을 구분하는 건 1차로 구현 완료했는데, 기록 하기 기능 까지 구현을 해야할지 고민이 되네요.
